### PR TITLE
Fix grenade explosion damage via collision check

### DIFF
--- a/PyGame/PART2ON/grenade.py
+++ b/PyGame/PART2ON/grenade.py
@@ -1,6 +1,5 @@
 import pygame, os
 import constants as c
-import player as pl
 
 
 class Grenade(pygame.sprite.Sprite):
@@ -13,8 +12,8 @@ class Grenade(pygame.sprite.Sprite):
         self.rect = self.image.get_rect()
         self.rect.center = (x, y)
         self.direction = direction
-    
-    def update(self, player):
+
+    def update(self, player, enemyGroup):
         self.vel_y += c.GRAVITY  # gravity
         dx = self.speed * self.direction
         dy = self.vel_y
@@ -31,18 +30,10 @@ class Grenade(pygame.sprite.Sprite):
         
         #countdown timer
         self.timer -= 1
-        if self.timer <= 0: 
+        if self.timer <= 0:
             self.kill()
             explosion = Explosion(self.rect.centerx, self.rect.centery, c.explosionScale)
             explosionGroup.add(explosion)
-            #do damage to anyone nearby
-            if abs(self.rect.centerx - player.rect.centerx) < c.TILESIZE * 2 and \
-                abs(self.rect.centery - player.rect.centery) < c.TILESIZE * 2:
-                    player.health -= c.EXPLOSION_DAMAGE
-            for enemy in pl.enemyGroup:
-                if abs(self.rect.centerx - enemy.rect.centerx) < c.TILESIZE * 2 and \
-                    abs(self.rect.centery - enemy.rect.centery) < c.TILESIZE * 2:
-                        enemy.health -= c.EXPLOSION_DAMAGE
                 
                 
 
@@ -62,11 +53,20 @@ class Explosion(pygame.sprite.Sprite):
         self.rect.center = (x, y)
         self.timer = 50
         self.counter = 0
-        
-    def update(self):
+        self.damageApplied = False
+
+    def update(self, player, enemyGroup):
+        if not self.damageApplied:
+            if pygame.sprite.collide_rect(self, player) and player.alive:
+                player.health -= c.EXPLOSION_DAMAGE
+            for enemy in enemyGroup:
+                if pygame.sprite.collide_rect(self, enemy) and enemy.alive:
+                    enemy.health -= c.EXPLOSION_DAMAGE
+            self.damageApplied = True
+
         #update explosion animation
-        self.counter += 1 
-        if self.counter >= c.explosionSpeed: 
+        self.counter += 1
+        if self.counter >= c.explosionSpeed:
             self.counter = 0
             self.frameIndex += 1
             if self.frameIndex >= len(self.images):
@@ -74,5 +74,5 @@ class Explosion(pygame.sprite.Sprite):
             else:
                 self.image = self.images[self.frameIndex]
         
-explosionGroup = pygame.sprite.Group()        
+explosionGroup = pygame.sprite.Group()
 grenadeGroup = pygame.sprite.Group()

--- a/PyGame/PART2ON/init.py
+++ b/PyGame/PART2ON/init.py
@@ -32,11 +32,11 @@ def Init(stats = None):
         pl.Player('enemy', **stats['enemy']),
         pl.Player('enemy', **stats['enemy2'])
     ]
-    
+
     pl.enemyGroup.add(*enemies)
-        
+
     drawBG(screen, BACKGROUND)
-    return screen, enemies, player, clock
+    return screen, pl.enemyGroup, player, clock
 
 def drawBG(screen, BACKGROUND):
     screen.fill(BACKGROUND)

--- a/PyGame/PART2ON/loop.py
+++ b/PyGame/PART2ON/loop.py
@@ -2,29 +2,28 @@ import pygame, init
 import constants as c
 import bullet as b
 import grenade as g
-import player as pl
 
-def main_loop(player, enemies, screen):
+def main_loop(player, enemyGroup, screen):
     
     init.drawBG(screen, init.BACKGROUND)  # draw background
     #player and enemy draw order
-    maxEnemyScale = max((enemy.scale for enemy in pl.enemyGroup), default = 0)
-    if len(enemies) > 0 and player.scale >= maxEnemyScale:
-        for enemy in pl.enemyGroup:
+    maxEnemyScale = max((enemy.scale for enemy in enemyGroup), default = 0)
+    if len(enemyGroup) > 0 and player.scale >= maxEnemyScale:
+        for enemy in enemyGroup:
             enemy.draw(screen)
         player.draw(screen)
     else:
         player.draw(screen)
-        for enemy in pl.enemyGroup:
+        for enemy in enemyGroup:
             enemy.draw(screen)
 
     player.update()
-    for enemy in pl.enemyGroup:
+    for enemy in enemyGroup:
         enemy.update()
     #update and draw groups
-    b.bulletGroup.update(player, pl.enemyGroup)
-    g.grenadeGroup.update(player)
-    g.explosionGroup.update()
+    b.bulletGroup.update(player, enemyGroup)
+    g.grenadeGroup.update(player, enemyGroup)
+    g.explosionGroup.update(player, enemyGroup)
     b.bulletGroup.draw(screen)
     g.grenadeGroup.draw(screen)
     g.explosionGroup.draw(screen)
@@ -48,7 +47,7 @@ def main_loop(player, enemies, screen):
             player.updateAction(player.IDLE)#0 = idle
         player.move(screen)
     
-    for enemy in pl.enemyGroup:
+    for enemy in enemyGroup:
         enemy.move(screen)
     
     for event in pygame.event.get():
@@ -99,5 +98,4 @@ def main_loop(player, enemies, screen):
                 c.grenading = False
                 c.grenadeThrown = False
     pygame.display.flip()  #update the display
-                
-            
+

--- a/PyGame/PART2ON/main.py
+++ b/PyGame/PART2ON/main.py
@@ -1,12 +1,12 @@
 import pygame, init, loop
 import constants as c
 
-(screen, enemies, 
+(screen, enemyGroup,
     player, clock) = init.Init()
 
 while c.running:
     clock.tick(c.FPS)  # set FPS
-    loop.main_loop(player, enemies, screen) #main loopaa
+    loop.main_loop(player, enemyGroup, screen) #main loopaa
 
 pygame.quit()
 


### PR DESCRIPTION
## Summary
- Move grenade damage logic into the explosion sprite and apply damage once via rectangle collisions with the player and enemies
- Update the main loop to pass player and enemy groups into explosion updates for proper damage handling

## Testing
- `python -m py_compile PyGame/PART2ON/grenade.py PyGame/PART2ON/loop.py PyGame/PART2ON/init.py PyGame/PART2ON/main.py`
- `pip install pygame` *(fails: ProxyError: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689cd42a272883299fc4e570a05497da