### PR TITLE
Fix pygame font initialization order

### DIFF
--- a/PyGame/PART2ON/constants.py
+++ b/PyGame/PART2ON/constants.py
@@ -12,7 +12,8 @@ WEAPON_COOLDOWN = 0.5 #seconds
 BACKGROUND = (0, 0, 0)
 GREEN = (20, 255, 20)
 
-textFont = pygame.font.SysFont('Futura', 30)
+# Font placeholder; initialized after pygame.init()
+textFont = None
 
 running = True
 movingLeft = False

--- a/PyGame/PART2ON/init.py
+++ b/PyGame/PART2ON/init.py
@@ -14,6 +14,8 @@ def Init(stats = None):
     stats = stats or STATS
     pygame.init()
     clock = pygame.time.Clock()
+    # Initialize fonts now that pygame is ready
+    c.textFont = pygame.font.SysFont('Futura', 30)
     os.system(c.CLEAR)  # Clear terminal depending on OS
     screen = pygame.display.set_mode((c.WIDTH, c.HEIGHT))
     


### PR DESCRIPTION
## Summary
- delay font creation until after pygame is initialized to prevent font errors

## Testing
- `SDL_VIDEODRIVER=dummy python main.py` *(fails: ModuleNotFoundError: No module named 'pygame')*
- `pip install pygame` *(fails: Could not find a version that satisfies the requirement pygame; proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a066bee6048329852675c628b9f6ee